### PR TITLE
Use clap fork with backported fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -236,8 +236,7 @@ dependencies = [
 [[package]]
 name = "clap"
 version = "2.34.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0610544180c38b88101fecf2dd634b174a62eef6946f84dfc6a7127512b381c"
+source = "git+https://github.com/kentik/clap?rev=040d70fec261e25d3fe6a8fea1a314d7ca66b388#040d70fec261e25d3fe6a8fea1a314d7ca66b388"
 dependencies = [
  "ansi_term",
  "atty",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ version  = "1.0.57"
 features = ["backtrace"]
 
 [dependencies.clap]
-version  = "2.33.3"
+version  = "2.34.0"
 features = ["yaml"]
 
 [dependencies.ed25519-compact]
@@ -151,3 +151,7 @@ debug = true
 
 [profile.release.package."*"]
 debug = false
+
+[patch.crates-io.clap]
+git   = "https://github.com/kentik/clap"
+rev   = "040d70fec261e25d3fe6a8fea1a314d7ca66b388"


### PR DESCRIPTION
The arg parsing library ksynth uses, clap, has an unfixed bug (https://github.com/clap-rs/clap/issues/1835) where environment variables are used as an additional source of values instead of being used as a fallback. This is fixed in v3+ but those versions have removed support for configuration via YAML which ksynth depends on.

This PR switches clap to a kentik fork with this fix backported. Fixes #3.