### PR TITLE
New stable distro packages

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -133,7 +133,7 @@ jobs:
         run: |
           BUCKET=$BUCKET/${{ needs.version.outputs.version }}
           aws s3 cp $BUCKET . --include "*.deb" --include "*.rpm" --recursive
-      - uses: actions/setup-ruby@v1
+      - uses: ruby/setup-ruby@v1
         with:
           ruby-version: 2.6
       - run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -145,17 +145,20 @@ jobs:
           esac
 
           for deb in *.deb; do
-              package_cloud push kentik/$REPO/debian/jessie  $deb
-              package_cloud push kentik/$REPO/debian/stretch $deb
-              package_cloud push kentik/$REPO/debian/buster  $deb
+              package_cloud push kentik/$REPO/debian/jessie   $deb
+              package_cloud push kentik/$REPO/debian/stretch  $deb
+              package_cloud push kentik/$REPO/debian/buster   $deb
+              package_cloud push kentik/$REPO/debian/bullseye $deb
 
-              package_cloud push kentik/$REPO/ubuntu/focal   $deb
-              package_cloud push kentik/$REPO/ubuntu/bionic  $deb
+              package_cloud push kentik/$REPO/ubuntu/focal    $deb
+              package_cloud push kentik/$REPO/ubuntu/bionic   $deb
+              package_cloud push kentik/$REPO/ubuntu/jammy    $deb
           done
 
           for rpm in *.rpm; do
               package_cloud push kentik/$REPO/el/7 $rpm
               package_cloud push kentik/$REPO/el/8 $rpm
+              package_cloud push kentik/$REPO/el/9 $rpm
           done
         env:
           PACKAGECLOUD_TOKEN: ${{ secrets.PACKAGECLOUD_TOKEN }}


### PR DESCRIPTION
Build packages for latest stable Linux distributions, and switch to ruby/setup-ruby action since actions/setup-ruby has been deprecated and is now broken.
